### PR TITLE
feat: remove redundant app code-base from 2 test-cases

### DIFF
--- a/compositions/cluster-k8s/gen-validators.toml
+++ b/compositions/cluster-k8s/gen-validators.toml
@@ -10,6 +10,9 @@
   runner = "cluster:k8s"
   disable_metrics = false
 
+[global.run.test_params]
+  persistent-peers = "10"
+
 [[groups]]
   id = "validators"
   builder = "docker:generic"

--- a/compositions/cluster-k8s/gen-validators.toml
+++ b/compositions/cluster-k8s/gen-validators.toml
@@ -11,6 +11,7 @@
   disable_metrics = false
 
 [global.run.test_params]
+  validator = "80"
   persistent-peers = "10"
 
 [[groups]]

--- a/compositions/local-docker/gen-validators.toml
+++ b/compositions/local-docker/gen-validators.toml
@@ -10,6 +10,9 @@
   runner = "local:docker"
   disable_metrics = false
 
+[global.run.test_params]
+  persistent-peers = "3"
+
 [[groups]]
   id = "validators"
   builder = "docker:generic"

--- a/compositions/local-docker/gen-validators.toml
+++ b/compositions/local-docker/gen-validators.toml
@@ -11,6 +11,7 @@
   disable_metrics = false
 
 [global.run.test_params]
+  validator = "3"
   persistent-peers = "3"
 
 [[groups]]

--- a/manifest.toml
+++ b/manifest.toml
@@ -20,6 +20,7 @@ enabled = true
 name = "init-val"
 instances = { min = 1, max = 100, default = 3 }
     [testcases.params]
+    validator = { type = "int", default = 3}
     persistent-peers = { type = "int", default = 3}
 
 [[testcases]]

--- a/manifest.toml
+++ b/manifest.toml
@@ -19,6 +19,8 @@ enabled = true
 [[testcases]]
 name = "init-val"
 instances = { min = 1, max = 100, default = 3 }
+    [testcases.params]
+    persistent-peers = { type = "int", default = 3}
 
 [[testcases]]
 name = "node-sync"

--- a/testkit/appkit/app.go
+++ b/testkit/appkit/app.go
@@ -73,7 +73,7 @@ func (ak *AppKit) GetHomePath() string {
 }
 
 func (ak *AppKit) InitChain(moniker string, chainId string) (string, error) {
-	ak.AccountAddress = chainId
+	ak.ChainId = chainId
 	return ak.execCmd([]string{"init", moniker, "--chain-id", chainId, "--home", ak.home})
 }
 

--- a/testkit/appkit/app.go
+++ b/testkit/appkit/app.go
@@ -33,10 +33,11 @@ type AppKit struct {
 	Cmd            *cobra.Command
 }
 
-func New(path string) *AppKit {
+func New(path, chainId string) *AppKit {
 	return &AppKit{
-		home: path,
-		Cmd:  appcmd.NewRootCmd(),
+		home:    path,
+		ChainId: chainId,
+		Cmd:     appcmd.NewRootCmd(),
 	}
 }
 
@@ -72,9 +73,8 @@ func (ak *AppKit) GetHomePath() string {
 	return ak.home
 }
 
-func (ak *AppKit) InitChain(moniker string, chainId string) (string, error) {
-	ak.ChainId = chainId
-	return ak.execCmd([]string{"init", moniker, "--chain-id", chainId, "--home", ak.home})
+func (ak *AppKit) InitChain(moniker string) (string, error) {
+	return ak.execCmd([]string{"init", moniker, "--chain-id", ak.ChainId, "--home", ak.home})
 }
 
 func (ak *AppKit) CreateKey(name string, krbackend string, krpath string) (string, error) {
@@ -110,13 +110,13 @@ func (ak *AppKit) StartNode(loglvl string) error {
 	return svrcmd.Execute(ak.Cmd, appcmd.EnvPrefix, app.DefaultNodeHome)
 }
 
-func (ak *AppKit) PayForData(accAdr string, msg int, krbackend, chainId, krpath string) error {
+func (ak *AppKit) PayForData(accAdr string, msg int, krbackend, krpath string) error {
 	ak.Cmd.ResetFlags()
 	ak.Cmd.SetArgs([]string{
 		"tx", "payment", "payForData", fmt.Sprint(msg),
 		"--from", accAdr, "-b", "block", "-y", "--gas", "1000000000",
 		"--fees", "100000000000utia",
-		"--keyring-backend", krbackend, "--chain-id", chainId, "--home", ak.home, "--keyring-dir", krpath,
+		"--keyring-backend", krbackend, "--chain-id", ak.ChainId, "--home", ak.home, "--keyring-dir", krpath,
 	})
 
 	return svrcmd.Execute(ak.Cmd, appcmd.EnvPrefix, app.DefaultNodeHome)

--- a/testkit/appkit/app.go
+++ b/testkit/appkit/app.go
@@ -77,7 +77,7 @@ func (ak *AppKit) InitChain(moniker string) (string, error) {
 	return ak.execCmd([]string{"init", moniker, "--chain-id", ak.ChainId, "--home", ak.home})
 }
 
-func (ak *AppKit) CreateKey(name string, krbackend string, krpath string) (string, error) {
+func (ak *AppKit) CreateKey(name, krbackend, krpath string) (string, error) {
 	_, err := ak.execCmd([]string{"keys", "add", name, "--keyring-backend", krbackend, "--home", ak.home, "--keyring-dir", krpath})
 	if err != nil {
 		return "", err
@@ -85,12 +85,12 @@ func (ak *AppKit) CreateKey(name string, krbackend string, krpath string) (strin
 	return ak.execCmd([]string{"keys", "show", name, "-a", "--keyring-backend", krbackend, "--home", ak.home, "--keyring-dir", krpath})
 }
 
-func (ak *AppKit) AddGenAccount(addr string, amount string) (string, error) {
+func (ak *AppKit) AddGenAccount(addr, amount string) (string, error) {
 	return ak.execCmd([]string{"add-genesis-account", addr, amount, "--home", ak.home})
 }
 
-func (ak *AppKit) SignGenTx(accName string, amount string, krbackend string, chainId string, krpath string) (string, error) {
-	return ak.execCmd([]string{"gentx", accName, amount, "--keyring-backend", krbackend, "--chain-id", chainId, "--home", ak.home, "--keyring-dir", krpath})
+func (ak *AppKit) SignGenTx(accName, amount, krbackend, krpath string) (string, error) {
+	return ak.execCmd([]string{"gentx", accName, amount, "--keyring-backend", krbackend, "--chain-id", ak.ChainId, "--home", ak.home, "--keyring-dir", krpath})
 }
 
 func (ak *AppKit) CollectGenTxs() (string, error) {

--- a/testkit/appkit/app.go
+++ b/testkit/appkit/app.go
@@ -26,13 +26,17 @@ type ValidatorNode struct {
 }
 
 type AppKit struct {
-	m   sync.Mutex
-	Cmd *cobra.Command
+	m              sync.Mutex
+	home           string
+	AccountAddress string
+	ChainId        string
+	Cmd            *cobra.Command
 }
 
-func New() *AppKit {
+func New(path string) *AppKit {
 	return &AppKit{
-		Cmd: appcmd.NewRootCmd(),
+		home: path,
+		Cmd:  appcmd.NewRootCmd(),
 	}
 }
 
@@ -64,50 +68,55 @@ func (ak *AppKit) execCmd(args []string) (output string, err error) {
 	return output, nil
 }
 
-func (ak *AppKit) InitChain(moniker string, chainId string, home string) (string, error) {
-	return ak.execCmd([]string{"init", moniker, "--chain-id", chainId, "--home", home})
+func (ak *AppKit) GetHomePath() string {
+	return ak.home
 }
 
-func (ak *AppKit) CreateKey(name string, krbackend string, home string) (string, error) {
-	_, err := ak.execCmd([]string{"keys", "add", name, "--keyring-backend", krbackend, "--home", home, "--keyring-dir", home})
+func (ak *AppKit) InitChain(moniker string, chainId string) (string, error) {
+	ak.AccountAddress = chainId
+	return ak.execCmd([]string{"init", moniker, "--chain-id", chainId, "--home", ak.home})
+}
+
+func (ak *AppKit) CreateKey(name string, krbackend string, krpath string) (string, error) {
+	_, err := ak.execCmd([]string{"keys", "add", name, "--keyring-backend", krbackend, "--home", ak.home, "--keyring-dir", krpath})
 	if err != nil {
 		return "", err
 	}
-	return ak.execCmd([]string{"keys", "show", name, "-a", "--keyring-backend", krbackend, "--home", home, "--keyring-dir", home})
+	return ak.execCmd([]string{"keys", "show", name, "-a", "--keyring-backend", krbackend, "--home", ak.home, "--keyring-dir", krpath})
 }
 
-func (ak *AppKit) AddGenAccount(addr string, amount string, home string) (string, error) {
-	return ak.execCmd([]string{"add-genesis-account", addr, amount, "--home", home})
+func (ak *AppKit) AddGenAccount(addr string, amount string) (string, error) {
+	return ak.execCmd([]string{"add-genesis-account", addr, amount, "--home", ak.home})
 }
 
-func (ak *AppKit) SignGenTx(accName string, amount string, krbackend string, chainId string, home string) (string, error) {
-	return ak.execCmd([]string{"gentx", accName, amount, "--keyring-backend", krbackend, "--chain-id", chainId, "--home", home, "--keyring-dir", home})
+func (ak *AppKit) SignGenTx(accName string, amount string, krbackend string, chainId string, krpath string) (string, error) {
+	return ak.execCmd([]string{"gentx", accName, amount, "--keyring-backend", krbackend, "--chain-id", chainId, "--home", ak.home, "--keyring-dir", krpath})
 }
 
-func (ak *AppKit) CollectGenTxs(home string) (string, error) {
-	return ak.execCmd([]string{"collect-gentxs", "--home", home})
+func (ak *AppKit) CollectGenTxs() (string, error) {
+	return ak.execCmd([]string{"collect-gentxs", "--home", ak.home})
 }
 
-func (ak *AppKit) GetNodeId(home string) (string, error) {
-	return ak.execCmd([]string{"tendermint", "show-node-id", "--home", home})
+func (ak *AppKit) GetNodeId() (string, error) {
+	return ak.execCmd([]string{"tendermint", "show-node-id", "--home", ak.home})
 }
 
-func (ak *AppKit) StartNode(home, loglvl string) error {
+func (ak *AppKit) StartNode(loglvl string) error {
 	ak.Cmd.ResetFlags()
 
 	ak.Cmd.SetErr(os.Stdout)
-	ak.Cmd.SetArgs([]string{"start", "--home", home, "--log_level", loglvl, "--log_format", "plain"})
+	ak.Cmd.SetArgs([]string{"start", "--home", ak.home, "--log_level", loglvl, "--log_format", "plain"})
 
 	return svrcmd.Execute(ak.Cmd, appcmd.EnvPrefix, app.DefaultNodeHome)
 }
 
-func (ak *AppKit) PayForData(accAdr string, msg int, krbackend, chainId, home string) error {
+func (ak *AppKit) PayForData(accAdr string, msg int, krbackend, chainId, krpath string) error {
 	ak.Cmd.ResetFlags()
 	ak.Cmd.SetArgs([]string{
 		"tx", "payment", "payForData", fmt.Sprint(msg),
 		"--from", accAdr, "-b", "block", "-y", "--gas", "1000000000",
 		"--fees", "100000000000utia",
-		"--keyring-backend", krbackend, "--chain-id", chainId, "--home", home, "--keyring-dir", home,
+		"--keyring-backend", krbackend, "--chain-id", chainId, "--home", ak.home, "--keyring-dir", krpath,
 	})
 
 	return svrcmd.Execute(ak.Cmd, appcmd.EnvPrefix, app.DefaultNodeHome)

--- a/tests/app-sync/run_seeds.go
+++ b/tests/app-sync/run_seeds.go
@@ -53,9 +53,9 @@ func RunSeed(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 	home := fmt.Sprintf("/.celestia-app-%d", initCtx.GroupSeq)
 	runenv.RecordMessage(home)
 
-	cmd := appkit.New()
+	cmd := appkit.New(home)
 
-	nodeId, err := cmd.GetNodeId(home)
+	nodeId, err := cmd.GetNodeId()
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func RunSeed(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 		return err
 	}
 
-	go cmd.StartNode(home, "info")
+	go cmd.StartNode("info")
 
 	// // wait for a new block to be produced
 	time.Sleep(1 * time.Minute)

--- a/tests/app-sync/run_seeds.go
+++ b/tests/app-sync/run_seeds.go
@@ -53,7 +53,7 @@ func RunSeed(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 	home := fmt.Sprintf("/.celestia-app-%d", initCtx.GroupSeq)
 	runenv.RecordMessage(home)
 
-	cmd := appkit.New(home)
+	cmd := appkit.New(home, "tia-test")
 
 	nodeId, err := cmd.GetNodeId()
 	if err != nil {

--- a/tests/app-sync/run_validator.go
+++ b/tests/app-sync/run_validator.go
@@ -71,14 +71,14 @@ func RunValidator(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 			runenv.RecordFailure(err)
 			return err
 		}
-		go func(i int) {
-			s, err := appkit.GetLatestsBlockSize(net.ParseIP("127.0.0.1"))
-			if err != nil {
-				runenv.RecordMessage("err in last size call, %s", err.Error())
-			}
+		// go func(i int) {
+		s, err := appkit.GetLatestsBlockSize(net.ParseIP("127.0.0.1"))
+		if err != nil {
+			runenv.RecordMessage("err in last size call, %s", err.Error())
+		}
 
-			runenv.RecordMessage("latest size on iteration %d of the block is - %d", i, s)
-		}(i)
+		runenv.RecordMessage("latest size on iteration %d of the block is - %d", i, s)
+		// }(i)
 	}
 
 	time.Sleep(30 * time.Second)

--- a/tests/app-sync/run_validator.go
+++ b/tests/app-sync/run_validator.go
@@ -71,14 +71,14 @@ func RunValidator(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 			runenv.RecordFailure(err)
 			return err
 		}
-		go func() {
+		go func(i int) {
 			s, err := appkit.GetLatestsBlockSize(net.ParseIP("127.0.0.1"))
 			if err != nil {
 				runenv.RecordMessage("err in last size call, %s", err.Error())
 			}
 
 			runenv.RecordMessage("latest size on iteration %d of the block is - %d", i, s)
-		}()
+		}(i)
 	}
 
 	time.Sleep(30 * time.Second)

--- a/tests/app-sync/run_validator.go
+++ b/tests/app-sync/run_validator.go
@@ -65,19 +65,17 @@ func RunValidator(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 			"test",
 			appcmd.GetHomePath(),
 		)
-
 		if err != nil {
 			runenv.RecordFailure(err)
 			return err
 		}
-		// go func(i int) {
+
 		s, err := appkit.GetLatestsBlockSize(net.ParseIP("127.0.0.1"))
 		if err != nil {
 			runenv.RecordMessage("err in last size call, %s", err.Error())
 		}
 
 		runenv.RecordMessage("latest size on iteration %d of the block is - %d", i, s)
-		// }(i)
 	}
 
 	time.Sleep(30 * time.Second)

--- a/tests/app-sync/run_validator.go
+++ b/tests/app-sync/run_validator.go
@@ -63,7 +63,6 @@ func RunValidator(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 			appcmd.AccountAddress,
 			50000,
 			"test",
-			appcmd.ChainId,
 			appcmd.GetHomePath(),
 		)
 

--- a/tests/common/doc.go
+++ b/tests/common/doc.go
@@ -1,0 +1,15 @@
+/*
+Package common is a helper around redundant creation of App or Node part
+
+In order to eliminate the boilerplate code of creating a validators' set,
+please use `common.BuildValidator`. This Func does:
+- InitChain
+- Add-Gen-Account
+- Collect-GenTxs
+- Add-Persistent-Peers
+In addition, the func returns initialized cobra cmd, so you can continue
+operating with the validator
+
+appcmd, err := common.BuildValidator(ctx, runenv, initCtx)
+appcmd.PayForData(...)
+*/

--- a/tests/common/doc.go
+++ b/tests/common/doc.go
@@ -13,3 +13,4 @@ operating with the validator
 appcmd, err := common.BuildValidator(ctx, runenv, initCtx)
 appcmd.PayForData(...)
 */
+package common

--- a/tests/common/validator.go
+++ b/tests/common/validator.go
@@ -1,4 +1,4 @@
-package appsync
+package common
 
 import (
 	"context"
@@ -8,62 +8,31 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/celestiaorg/test-infra/testkit"
 	"github.com/celestiaorg/test-infra/testkit/appkit"
-
-	"github.com/testground/sdk-go/network"
 	"github.com/testground/sdk-go/run"
 	"github.com/testground/sdk-go/runtime"
 )
 
-func RunValidator(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*4)
-	defer cancel()
-
+func BuildValidator(ctx context.Context, runenv *runtime.RunEnv, initCtx *run.InitContext) (*appkit.AppKit, error) {
 	syncclient := initCtx.SyncClient
-	netclient := network.NewClient(syncclient, runenv)
-
-	netclient.MustWaitNetworkInitialized(ctx)
-
-	config := network.Config{
-		Network: "default",
-		Enable:  true,
-		Default: network.LinkShape{
-			Bandwidth: 5 << 26, // 320Mib
-		},
-		CallbackState: "network-configured",
-		RoutingPolicy: network.AllowAll,
-	}
-
-	config.IPv4 = runenv.TestSubnet
-
-	// using the assigned `GlobalSequencer` id per each of instance
-	// to fill in the last 2 octects of the new IP address for the instance
-	ipC := byte((initCtx.GlobalSeq >> 8) + 1)
-	ipD := byte(initCtx.GlobalSeq)
-	config.IPv4.IP = append(config.IPv4.IP[0:2:2], ipC, ipD)
-
-	err := netclient.ConfigureNetwork(ctx, &config)
-	if err != nil {
-		return err
-	}
 
 	home := fmt.Sprintf("/.celestia-app-%d", initCtx.GlobalSeq)
 	runenv.RecordMessage(home)
 
-	cmd := appkit.New()
+	cmd := appkit.New(home)
 
 	keyringName := fmt.Sprintf("keyName-%d", initCtx.GlobalSeq)
 	accAddr, err := cmd.CreateKey(keyringName, "test", home)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	cmd.AccountAddress = accAddr
 
 	_, err = syncclient.Publish(ctx, testkit.AccountAddressTopic, accAddr)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Here we assign the first instance to be the orchestrator role
@@ -76,11 +45,11 @@ func RunValidator(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 		accAddrCh := make(chan string)
 		_, err = syncclient.Subscribe(ctx, testkit.AccountAddressTopic, accAddrCh)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		var accounts []string
-		for i := 0; i < runenv.TestGroupInstanceCount; i++ {
+		for i := 0; i < runenv.IntParam("validator"); i++ {
 			addr := <-accAddrCh
 			runenv.RecordMessage("Received address: %s", addr)
 			accounts = append(accounts, addr)
@@ -88,31 +57,31 @@ func RunValidator(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 
 		moniker := fmt.Sprintf("validator-%d", initCtx.GlobalSeq)
 
-		_, err = cmd.InitChain(moniker, chainId, home)
+		_, err = cmd.InitChain(moniker, chainId)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		for _, v := range accounts {
-			_, err := cmd.AddGenAccount(v, "100000000000000000utia", home)
+			_, err := cmd.AddGenAccount(v, "1000000000000000utia")
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 
 		gen, err := os.Open(fmt.Sprintf("%s/config/genesis.json", home))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		bt, err := ioutil.ReadAll(gen)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		_, err = syncclient.Publish(ctx, testkit.InitialGenenesisTopic, string(bt))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		runenv.RecordMessage("Orchestrator has sent initial genesis with accounts")
@@ -120,17 +89,17 @@ func RunValidator(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 		initGenCh := make(chan string)
 		sub, err := syncclient.Subscribe(ctx, testkit.InitialGenenesisTopic, initGenCh)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		select {
 		case err = <-sub.Done():
 			if err != nil {
-				return err
+				return nil, err
 			}
 		case initGen := <-initGenCh:
 			err = os.WriteFile(fmt.Sprintf("%s/config/genesis.json", home), []byte(initGen), 0777)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 		runenv.RecordMessage("Validator has received the initial genesis")
@@ -138,28 +107,28 @@ func RunValidator(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 
 	_, err = cmd.SignGenTx(keyringName, "5000000000utia", "test", chainId, home)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	fs, err := os.ReadDir(fmt.Sprintf("%s/config/gentx", home))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// slice is needed because of auto-gen gentx-name
 	for _, f := range fs {
 		gentx, err := os.Open(fmt.Sprintf("%s/config/gentx/%s", home, f.Name()))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		bt, err := ioutil.ReadAll(gentx)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		_, err = syncclient.Publish(ctx, testkit.GenesisTxTopic, string(bt))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 	}
@@ -167,36 +136,50 @@ func RunValidator(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 	genTxCh := make(chan string)
 	sub, err := syncclient.Subscribe(ctx, testkit.GenesisTxTopic, genTxCh)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	for i := 0; i < runenv.TestInstanceCount; i++ {
+	for i := 0; i < runenv.IntParam("validator"); i++ {
 		select {
 		case err = <-sub.Done():
 			if err != nil {
-				return err
+				return nil, err
 			}
 		case genTx := <-genTxCh:
 			if !strings.Contains(genTx, accAddr) {
 				err := ioutil.WriteFile(fmt.Sprintf("%s/config/gentx/%d.json", home, i), []byte(genTx), 0777)
 				if err != nil {
-					return err
+					return nil, err
 				}
 			}
 		}
 	}
 
-	_, err = cmd.CollectGenTxs(home)
+	_, err = cmd.CollectGenTxs()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	configPath := filepath.Join(home, "config", "config.toml")
+	err = appkit.ChangeRPCServerAddress(configPath, net.ParseIP("0.0.0.0"))
+	if err != nil {
+		return nil, err
+	}
 
-	if initCtx.GlobalSeq <= 10 {
-		nodeId, err := cmd.GetNodeId(home)
+	err = changeConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	ip, err := initCtx.NetClient.GetDataNetworkIP()
+	if err != nil {
+		return nil, err
+	}
+
+	if initCtx.GlobalSeq <= int64(runenv.IntParam("persistent-peers")) {
+		nodeId, err := cmd.GetNodeId()
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		_, err = syncclient.Publish(
@@ -204,83 +187,40 @@ func RunValidator(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 			testkit.ValidatorPeerTopic,
 			&appkit.ValidatorNode{
 				PubKey: nodeId,
-				IP:     config.IPv4.IP},
+				IP:     ip},
 		)
 		if err != nil {
-			return err
-		}
-	} else {
-		valCh := make(chan *appkit.ValidatorNode)
-		sub, err = syncclient.Subscribe(ctx, testkit.ValidatorPeerTopic, valCh)
-		if err != nil {
-			return err
-		}
-
-		var persPeers []string
-		for i := 0; i < 10; i++ {
-			select {
-			case err = <-sub.Done():
-				if err != nil {
-					return err
-				}
-			case val := <-valCh:
-				runenv.RecordMessage("Validator Received: %s, %s", val.IP, val.PubKey)
-				if !val.IP.Equal(config.IPv4.IP) {
-					persPeers = append(persPeers, fmt.Sprintf("%s@%s", val.PubKey, val.IP.To4().String()))
-				}
-
-				err = appkit.AddPersistentPeers(configPath, persPeers)
-				if err != nil {
-					return err
-				}
-			}
+			return nil, err
 		}
 	}
 
-	err = appkit.ChangeConfigParam(configPath, "p2p", "external_address", fmt.Sprintf("%s:26656", config.IPv4.IP.To4().String()))
+	valCh := make(chan *appkit.ValidatorNode)
+	sub, err = syncclient.Subscribe(ctx, testkit.ValidatorPeerTopic, valCh)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	runenv.RecordMessage("starting........")
 
-	err = changeConfig(configPath)
-	if err != nil {
-		return err
-	}
-	go cmd.StartNode(home, "info")
-
-	// // wait for a new block to be produced
-	time.Sleep(1 * time.Minute)
-
-	// If all 3 validators submit pfd - it will take too long to produce a new block
-	for i := 0; i < 10; i++ {
-		runenv.RecordMessage("Submitting PFD with 90k bytes random data")
-		err = cmd.PayForData(
-			accAddr,
-			50000,
-			"test",
-			chainId,
-			home,
-		)
-
-		if err != nil {
-			runenv.RecordFailure(err)
-			return err
-		}
-		go func() {
-			s, err := appkit.GetLatestsBlockSize(net.ParseIP("127.0.0.1"))
+	var persPeers []string
+	for i := 0; i < runenv.IntParam("validator"); i++ {
+		select {
+		case err = <-sub.Done():
 			if err != nil {
-				runenv.RecordMessage("err in last size call, %s", err.Error())
+				return nil, err
+			}
+		case val := <-valCh:
+			runenv.RecordMessage("Validator Received: %s, %s", val.IP, val.PubKey)
+			if !val.IP.Equal(ip) {
+				persPeers = append(persPeers, fmt.Sprintf("%s@%s", val.PubKey, val.IP.To4().String()))
 			}
 
-			runenv.RecordMessage("latest size on iteration %d of the block is - %d", i, s)
-		}()
+			err = appkit.AddPersistentPeers(configPath, persPeers)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
-	time.Sleep(30 * time.Second)
-	runenv.RecordSuccess()
-
-	return nil
+	return cmd, nil
 }
 
 func changeConfig(path string) error {
@@ -289,7 +229,7 @@ func changeConfig(path string) error {
 			"timeout_propose":   "3s",
 			"timeout_prevote":   "1s",
 			"timeout_precommit": "1s",
-			"timeout_commit":    "30s",
+			"timeout_commit":    "25s",
 		},
 		"rpc": {
 			"timeout_broadcast_tx_commit": "90s",

--- a/tests/common/validator.go
+++ b/tests/common/validator.go
@@ -57,7 +57,7 @@ func BuildValidator(ctx context.Context, runenv *runtime.RunEnv, initCtx *run.In
 
 		moniker := fmt.Sprintf("validator-%d", initCtx.GlobalSeq)
 
-		_, err = cmd.InitChain(moniker, chainId)
+		_, err = cmd.InitChain(moniker)
 		if err != nil {
 			return nil, err
 		}
@@ -105,7 +105,7 @@ func BuildValidator(ctx context.Context, runenv *runtime.RunEnv, initCtx *run.In
 		runenv.RecordMessage("Validator has received the initial genesis")
 	}
 
-	_, err = cmd.SignGenTx(keyringName, "5000000000utia", "test", chainId, home)
+	_, err = cmd.SignGenTx(keyringName, "5000000000utia", "test", home)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/common/validator.go
+++ b/tests/common/validator.go
@@ -21,7 +21,8 @@ func BuildValidator(ctx context.Context, runenv *runtime.RunEnv, initCtx *run.In
 	home := fmt.Sprintf("/.celestia-app-%d", initCtx.GlobalSeq)
 	runenv.RecordMessage(home)
 
-	cmd := appkit.New(home)
+	const chainId string = "tia-test"
+	cmd := appkit.New(home, chainId)
 
 	keyringName := fmt.Sprintf("keyName-%d", initCtx.GlobalSeq)
 	accAddr, err := cmd.CreateKey(keyringName, "test", home)
@@ -40,7 +41,6 @@ func BuildValidator(ctx context.Context, runenv *runtime.RunEnv, initCtx *run.In
 	// Orchestrator is receiving all accounts by subscription, to then
 	// execute the `add-genesis-account` command and send back to the rest
 	// of the validators to set the initial genesis.json
-	const chainId string = "tia-test"
 	if initCtx.GlobalSeq == 1 {
 		accAddrCh := make(chan string)
 		_, err = syncclient.Subscribe(ctx, testkit.AccountAddressTopic, accAddrCh)

--- a/tests/node-sync/run_light.go
+++ b/tests/node-sync/run_light.go
@@ -31,7 +31,6 @@ func RunLightNode(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 		Network: "default",
 		Enable:  true,
 		Default: network.LinkShape{
-			// Latency:   100 * time.Millisecond,
 			Bandwidth: 5 << 26, // 320Mib
 		},
 		CallbackState: "network-configured",


### PR DESCRIPTION
Move the creation of a validator to the common dir
Adjusted the init-validator case to accept the pers-peers param
Move home path to app struct to eliminate passing home var to all methods

This is housekeeping part to start implementing #55 
Closes #46 