### PR TITLE
feat: implementation of TC#005

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+*.log
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please install `docker` and [testground](https://docs.testground.ai/v/master/get
 
 | Requirement | Notes          |
 | ----------- | -------------- |
-| Go version  | 1.18 or higher |
+| Go version  | 1.19 or higher |
 
 ## System Requirements
 

--- a/compositions/local-docker/005-light-das-past-12.toml
+++ b/compositions/local-docker/005-light-das-past-12.toml
@@ -1,0 +1,108 @@
+[metadata]
+  name = "005-light-das-past-3-3-3-3-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "005-light-das-past"
+  total_instances = 12
+  builder = "docker:generic"
+  runner = "local:docker"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "30"
+  persistent-peers = "3"
+  submit-times = "42"
+  msg-size = "100000"
+  validator = "3"
+  bridge = "3"
+  full = "3"
+  light = "3"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = ""
+    cpu = ""
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = ""
+    cpu = ""
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "30"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = ""
+    cpu = ""
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "40"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = ""
+    cpu = ""
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "100Mib"
+    block-height = "40"
+    role = "light"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/celestiaorg/celestia-app => github.com/Bidon15/lazyledger-app v1.4.1-dirty-app
-	// github.com/celestiaorg/celestia-node => github.com/Bidon15/celestia-node v0.4.5-dirty
+	github.com/celestiaorg/celestia-node => github.com/Bidon15/celestia-node v0.4.6-dirty
 	github.com/cosmos/cosmos-sdk => github.com/Bidon15/cosmos-sdk v1.2.0-dirty-sdk-v0.46.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/ipfs/go-log/v2 => github.com/Bidon15/go-log/v2 v2.5.2

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/celestiaorg/celestia-app => github.com/Bidon15/lazyledger-app v1.4.1-dirty-app
-	github.com/celestiaorg/celestia-node => github.com/Bidon15/celestia-node v0.4.5-dirty
+	// github.com/celestiaorg/celestia-node => github.com/Bidon15/celestia-node v0.4.5-dirty
 	github.com/cosmos/cosmos-sdk => github.com/Bidon15/cosmos-sdk v1.2.0-dirty-sdk-v0.46.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/ipfs/go-log/v2 => github.com/Bidon15/go-log/v2 v2.5.2
@@ -26,7 +26,7 @@ require (
 )
 
 require (
-	github.com/celestiaorg/celestia-node v0.3.2-0.20220923084512-cec6a2d65358
+	github.com/celestiaorg/celestia-node v0.3.2-0.20220927120802-81c63db9b6a8
 	github.com/tendermint/tendermint v0.35.4
 	go.uber.org/fx v1.18.1
 )

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,6 @@ github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.3.0/go.mod h1:tPaiy8S5bQ
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-autorest v11.1.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
-github.com/Bidon15/celestia-node v0.4.5-dirty h1:WzZ7NzKWdq/AYSUgXyVdEjm2MXm2VPVZSbXw/XmaV0s=
-github.com/Bidon15/celestia-node v0.4.5-dirty/go.mod h1:LfuGhWgoSdmZ4W4y2oceCNwec15io/dCd+xx/Q/fOs8=
 github.com/Bidon15/cosmos-sdk v1.2.0-dirty-sdk-v0.46.0 h1:rpLt48XTOb+xu4HfXXKSzeI3ZaGnaHnNwrGP08S06Hs=
 github.com/Bidon15/cosmos-sdk v1.2.0-dirty-sdk-v0.46.0/go.mod h1:OXRC0p460CFKl77uQZWY/8p5uZmDrNum7BmVZDupq0Q=
 github.com/Bidon15/go-log/v2 v2.5.2 h1:i+Co+D6OJQnM9xuuAlbtoV2GdnCv4KrfJWH6IQjcM1Y=
@@ -221,6 +219,8 @@ github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOC
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v1.3.3-tm-v0.34.20 h1:XspZtkoIfJ68TCVOOGWkI4W7taQFJLLqSu6GME5RbqU=
 github.com/celestiaorg/celestia-core v1.3.3-tm-v0.34.20/go.mod h1:f4R8qNJrP1CDH0SNwj4jA3NymBLQM4lNdx6Ijmfllbw=
+github.com/celestiaorg/celestia-node v0.3.2-0.20220927120802-81c63db9b6a8 h1:bTtfoYwO18bfRQfLnI3EUn9WiLWbMYVlqDl8lXaZ6Xk=
+github.com/celestiaorg/celestia-node v0.3.2-0.20220927120802-81c63db9b6a8/go.mod h1:LfuGhWgoSdmZ4W4y2oceCNwec15io/dCd+xx/Q/fOs8=
 github.com/celestiaorg/go-leopard v0.1.0 h1:28z2EkvKJIez5J9CEaiiUEC+OxalRLtTGJJ1oScfE1g=
 github.com/celestiaorg/go-leopard v0.1.0/go.mod h1:NtO/rjlB8dw2aq7jr06vZFKGvryQcTDXaNHelmPNOAM=
 github.com/celestiaorg/go-libp2p-messenger v0.1.0 h1:rFldTa3ZWcRRn8E2bRWS94Qp1GFYXO2a0uvqpIey1B8=

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.3.0/go.mod h1:tPaiy8S5bQ
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-autorest v11.1.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/Bidon15/celestia-node v0.4.6-dirty h1:ZmkeTy2DdM4VZpaayQf8wy89nW7/3Pu6LQP1ELojxkU=
+github.com/Bidon15/celestia-node v0.4.6-dirty/go.mod h1:LfuGhWgoSdmZ4W4y2oceCNwec15io/dCd+xx/Q/fOs8=
 github.com/Bidon15/cosmos-sdk v1.2.0-dirty-sdk-v0.46.0 h1:rpLt48XTOb+xu4HfXXKSzeI3ZaGnaHnNwrGP08S06Hs=
 github.com/Bidon15/cosmos-sdk v1.2.0-dirty-sdk-v0.46.0/go.mod h1:OXRC0p460CFKl77uQZWY/8p5uZmDrNum7BmVZDupq0Q=
 github.com/Bidon15/go-log/v2 v2.5.2 h1:i+Co+D6OJQnM9xuuAlbtoV2GdnCv4KrfJWH6IQjcM1Y=
@@ -219,8 +221,6 @@ github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOC
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v1.3.3-tm-v0.34.20 h1:XspZtkoIfJ68TCVOOGWkI4W7taQFJLLqSu6GME5RbqU=
 github.com/celestiaorg/celestia-core v1.3.3-tm-v0.34.20/go.mod h1:f4R8qNJrP1CDH0SNwj4jA3NymBLQM4lNdx6Ijmfllbw=
-github.com/celestiaorg/celestia-node v0.3.2-0.20220927120802-81c63db9b6a8 h1:bTtfoYwO18bfRQfLnI3EUn9WiLWbMYVlqDl8lXaZ6Xk=
-github.com/celestiaorg/celestia-node v0.3.2-0.20220927120802-81c63db9b6a8/go.mod h1:LfuGhWgoSdmZ4W4y2oceCNwec15io/dCd+xx/Q/fOs8=
 github.com/celestiaorg/go-leopard v0.1.0 h1:28z2EkvKJIez5J9CEaiiUEC+OxalRLtTGJJ1oScfE1g=
 github.com/celestiaorg/go-leopard v0.1.0/go.mod h1:NtO/rjlB8dw2aq7jr06vZFKGvryQcTDXaNHelmPNOAM=
 github.com/celestiaorg/go-libp2p-messenger v0.1.0 h1:rFldTa3ZWcRRn8E2bRWS94Qp1GFYXO2a0uvqpIey1B8=

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ var testcases = map[string]interface{}{
 	"001-val-large-txs":  run.InitializedTestCaseFn(tests.ValSubmitLargeTxs),
 	"002-da-sync":        run.InitializedTestCaseFn(tests.SyncNodes),
 	"003-full-sync-past": run.InitializedTestCaseFn(tests.FullSyncPast),
+	"005-light-das-past": run.InitializedTestCaseFn(tests.LightDasPast),
 }
 
 func main() {

--- a/manifest.toml
+++ b/manifest.toml
@@ -61,3 +61,20 @@ instances = { min = 4, max = 3000, default = 12 }
     light = { type = "int", default = 3}
     block-height = { type = "int" }
     role = { type = "string" }
+
+[[testcases]]
+name = "005-light-das-past"
+instances = { min = 4, max = 3000, default = 12 }
+    [testcases.params]
+    execution-time = { type = "int" }
+    latency = { type = "int", default = 0}
+    bandwidth = { type = "string", default = "256Mib"}
+    validator = { type = "int", default = 3}
+    persistent-peers = { type = "int", default = 3}
+    submit-times = { type = "int", default = 4}
+    msg-size = { type = "int", default = 10000}
+    bridge = { type = "int", default = 3}
+    full = { type = "int", default = 3}
+    light = { type = "int", default = 3}
+    block-height = { type = "int" }
+    role = { type = "string" }

--- a/tests/common/validator.go
+++ b/tests/common/validator.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/celestiaorg/test-infra/testkit"
 	"github.com/celestiaorg/test-infra/testkit/appkit"
@@ -31,6 +32,9 @@ func BuildValidator(ctx context.Context, runenv *runtime.RunEnv, initCtx *run.In
 	}
 	cmd.AccountAddress = accAddr
 
+	// we need this dirty-hack to check the k8s cluster has
+	// the time to ramp up all the instances
+	time.Sleep(30 * time.Second)
 	seq, err := syncclient.Publish(ctx, testkit.AccountAddressTopic, accAddr)
 	if err != nil {
 		return nil, err
@@ -229,10 +233,10 @@ func changeConfig(path string) error {
 			"timeout_propose":   "3s",
 			"timeout_prevote":   "1s",
 			"timeout_precommit": "1s",
-			"timeout_commit":    "25s",
+			"timeout_commit":    "15s",
 		},
 		"rpc": {
-			"timeout_broadcast_tx_commit": "90s",
+			"timeout_broadcast_tx_commit": "30s",
 			"max_body_bytes":              "1000000",
 			"max_header_bytes":            "1048576",
 		},

--- a/tests/sync-past/run_light.go
+++ b/tests/sync-past/run_light.go
@@ -1,0 +1,130 @@
+package syncpast
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/celestiaorg/celestia-node/nodebuilder/node"
+	"github.com/celestiaorg/test-infra/testkit"
+	"github.com/celestiaorg/test-infra/testkit/nodekit"
+	"github.com/celestiaorg/test-infra/tests/common"
+	"github.com/testground/sdk-go/network"
+	"github.com/testground/sdk-go/run"
+	"github.com/testground/sdk-go/runtime"
+)
+
+func RunLightNode(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		time.Minute*time.Duration(runenv.IntParam("execution-time")),
+	)
+	defer cancel()
+
+	err := nodekit.SetLoggersLevel("DEBUG")
+	if err != nil {
+		return err
+	}
+
+	syncclient := initCtx.SyncClient
+	netclient := network.NewClient(syncclient, runenv)
+
+	netclient.MustWaitNetworkInitialized(ctx)
+
+	config := network.Config{
+		Network: "default",
+		Enable:  true,
+		Default: network.LinkShape{
+			Latency:   time.Duration(runenv.IntParam("latency")),
+			Bandwidth: common.GetBandwidthValue(runenv.StringParam("bandwidth")),
+		},
+		CallbackState: "network-configured",
+		RoutingPolicy: network.AllowAll,
+	}
+
+	config.IPv4 = runenv.TestSubnet
+
+	// using the assigned `GlobalSequencer` id per each of instance
+	// to fill in the last 2 octects of the new IP address for the instance
+	ipC := byte((initCtx.GlobalSeq >> 8) + 1)
+	ipD := byte(initCtx.GlobalSeq)
+	config.IPv4.IP = append(config.IPv4.IP[0:2:2], ipC, ipD)
+
+	err = netclient.ConfigureNetwork(ctx, &config)
+	if err != nil {
+		return err
+	}
+
+	bridgeNode, err := common.GetBridgeNode(ctx, syncclient, initCtx.GroupSeq, runenv.IntParam("bridge"))
+	if err != nil {
+		return err
+	}
+
+	ndhome := fmt.Sprintf("/.celestia-light-%d", initCtx.GlobalSeq)
+	runenv.RecordMessage(ndhome)
+
+	ip, err := initCtx.NetClient.GetDataNetworkIP()
+	if err != nil {
+		return err
+	}
+
+	// We wait until the bridge reaches a certain height and then start syncing the chain
+	b, err := syncclient.Barrier(ctx, testkit.PastBlocksGeneratedState, runenv.IntParam("bridge"))
+	berr := <-b.C
+	if err != nil || berr != nil {
+		return fmt.Errorf("error occured on barriering: err - %s, barrier err - %s", err, berr)
+	}
+
+	trustedPeers := []string{bridgeNode.Maddr}
+	cfg := nodekit.NewConfig(node.Full, ip, trustedPeers, bridgeNode.TrustedHash)
+	nd, err := nodekit.NewNode(
+		ndhome,
+		node.Full,
+		cfg,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = nd.Start(ctx)
+	if err != nil {
+		return err
+	}
+
+	eh, err := nd.HeaderServ.GetByHeight(ctx, uint64(runenv.IntParam("block-height")))
+	if err != nil {
+		return err
+	}
+	runenv.RecordMessage("Reached Block#%d contains Hash: %s",
+		runenv.IntParam("block-height"),
+		eh.Commit.BlockID.Hash.String())
+
+	if nd.HeaderServ.IsSyncing() {
+		runenv.RecordFailure(fmt.Errorf("light node is still syncing the past"))
+	}
+
+	st, err := nd.DASer.SamplingStats(ctx)
+	if err != nil {
+		return err
+	}
+
+	if st.CatchUpDone {
+		if st.SampledChainHead < uint64(runenv.IntParam("block-height")) {
+			runenv.RecordFailure(fmt.Errorf("light node is still dasing the past headers of the chain"))
+		}
+	} else {
+		runenv.RecordFailure(fmt.Errorf("light node is still catching up the chain"))
+	}
+
+	err = nd.Stop(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = syncclient.SignalEntry(ctx, testkit.FinishState)
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/tests/tc-005-light-das-past.go
+++ b/tests/tc-005-light-das-past.go
@@ -1,0 +1,30 @@
+package tests
+
+import (
+	nodesync "github.com/celestiaorg/test-infra/tests/node-sync"
+	syncpast "github.com/celestiaorg/test-infra/tests/sync-past"
+
+	"github.com/testground/sdk-go/run"
+	"github.com/testground/sdk-go/runtime"
+)
+
+// Test-Case #005 - Light nodes are DASing past headers faster than validators produce new ones
+// Description is in docs/test-plans/001-Big-Blocks/test-cases
+func LightDasPast(runenv *runtime.RunEnv, initCtx *run.InitContext) (err error) {
+	switch runenv.StringParam("role") {
+	case "validator":
+		err = nodesync.RunAppValidator(runenv, initCtx)
+	case "bridge":
+		err = syncpast.RunBridgeNode(runenv, initCtx)
+	case "full":
+		err = nodesync.RunFullNode(runenv, initCtx)
+	case "light":
+		err = syncpast.RunLightNode(runenv, initCtx)
+	}
+
+	if err != nil {
+		return err
+	}
+	runenv.RecordSuccess()
+	return nil
+}


### PR DESCRIPTION
Implementation of TC#005 Light nodes are dasing past headers faster than validators produce new ones

- bump versions of node containing new daser logs
- bump go version in readme.md
- does not contain k8s compositions (will be done in a separate PR)

Closes #62 