### PR TITLE
feat: add compositions for cluster on tc-005

### DIFF
--- a/compositions/cluster-k8s/sanity/002-da-sync-8.toml
+++ b/compositions/cluster-k8s/sanity/002-da-sync-8.toml
@@ -1,0 +1,108 @@
+[metadata]
+  name = "002-da-sync-3-3-3-3-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "002-da-sync"
+  total_instances = 8
+  builder = "docker:generic"
+  runner = "cluster:k8s"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "10"
+  persistent-peers = "3"
+  submit-times = "12"
+  msg-size = "100000"
+  validator = "3"
+  bridge = "3"
+  full = "1"
+  light = "1"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "2000m"
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "2000m"
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "11"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "3Gi"
+    cpu = "2000m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "10"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "2Gi"
+    cpu = "1500m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "100Mib"
+    block-height = "10"
+    role = "light"

--- a/compositions/cluster-k8s/sanity/005-light-das-past-8.toml
+++ b/compositions/cluster-k8s/sanity/005-light-das-past-8.toml
@@ -1,0 +1,108 @@
+[metadata]
+  name = "005-light-das-past-3-3-3-3-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "005-light-das-past"
+  total_instances = 8
+  builder = "docker:generic"
+  runner = "cluster:k8s"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "30"
+  persistent-peers = "3"
+  submit-times = "42"
+  msg-size = "300000"
+  validator = "3"
+  bridge = "3"
+  full = "1"
+  light = "1"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "4500m"
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "4500m"
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "30"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "16Gi"
+    cpu = "16000m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "40"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "2Gi"
+    cpu = "1500m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "100Mib"
+    block-height = "40"
+    role = "light"

--- a/compositions/cluster-k8s/tc-005-light-das-past/100-100-50-1000/320-100mib-0ms.toml
+++ b/compositions/cluster-k8s/tc-005-light-das-past/100-100-50-1000/320-100mib-0ms.toml
@@ -1,0 +1,108 @@
+[metadata]
+  name = "005-light-das-past-100-100-50-1000-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "005-light-das-past"
+  total_instances = 2250
+  builder = "docker:generic"
+  runner = "cluster:k8s"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "40"
+  persistent-peers = "10"
+  submit-times = "102"
+  msg-size = "40000"
+  validator = "100"
+  bridge = "100"
+  full = "50"
+  light = "1000"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 100
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "320Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 100
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "320Mib"
+    block-height = "50"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 50
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "320Mib"
+    block-height = "100"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "1Gi"
+    cpu = "1500m"
+  [groups.instances]
+    count = 1000
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "100Mib"
+    block-height = "100"
+    role = "light"

--- a/compositions/cluster-k8s/tc-005-light-das-past/100-100-50-1000/320-100mib-100ms.toml
+++ b/compositions/cluster-k8s/tc-005-light-das-past/100-100-50-1000/320-100mib-100ms.toml
@@ -1,0 +1,108 @@
+[metadata]
+  name = "005-light-das-past-100-100-50-1000-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "005-light-das-past"
+  total_instances = 2250
+  builder = "docker:generic"
+  runner = "cluster:k8s"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "40"
+  persistent-peers = "10"
+  submit-times = "102"
+  msg-size = "40000"
+  validator = "100"
+  bridge = "100"
+  full = "50"
+  light = "1000"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 100
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "100"
+    bandwidth = "320Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 100
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "100"
+    bandwidth = "320Mib"
+    block-height = "50"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 50
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "100"
+    bandwidth = "320Mib"
+    block-height = "100"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "1Gi"
+    cpu = "1500m"
+  [groups.instances]
+    count = 1000
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "100"
+    bandwidth = "100Mib"
+    block-height = "100"
+    role = "light"

--- a/compositions/cluster-k8s/tc-005-light-das-past/100-100-50-1000/320-100mib-200ms.toml
+++ b/compositions/cluster-k8s/tc-005-light-das-past/100-100-50-1000/320-100mib-200ms.toml
@@ -1,0 +1,108 @@
+[metadata]
+  name = "005-light-das-past-100-100-50-1000-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "005-light-das-past"
+  total_instances = 2250
+  builder = "docker:generic"
+  runner = "cluster:k8s"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "40"
+  persistent-peers = "10"
+  submit-times = "102"
+  msg-size = "40000"
+  validator = "100"
+  bridge = "100"
+  full = "50"
+  light = "1000"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 100
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "200"
+    bandwidth = "320Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 100
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "200"
+    bandwidth = "320Mib"
+    block-height = "50"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 50
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "200"
+    bandwidth = "320Mib"
+    block-height = "100"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "1Gi"
+    cpu = "1500m"
+  [groups.instances]
+    count = 1000
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "200"
+    bandwidth = "100Mib"
+    block-height = "100"
+    role = "light"

--- a/compositions/cluster-k8s/tc-005-light-das-past/40-40-20-100/256-100mib-0ms.toml
+++ b/compositions/cluster-k8s/tc-005-light-das-past/40-40-20-100/256-100mib-0ms.toml
@@ -1,0 +1,108 @@
+[metadata]
+  name = "005-light-das-past-40-40-20-100-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "005-light-das-past"
+  total_instances = 200
+  builder = "docker:generic"
+  runner = "cluster:k8s"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "20"
+  persistent-peers = "10"
+  submit-times = "52"
+  msg-size = "100000"
+  validator = "40"
+  bridge = "40"
+  full = "20"
+  light = "100"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 40
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 40
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "30"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 20
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "50"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "1Gi"
+    cpu = "1500m"
+  [groups.instances]
+    count = 100
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "100Mib"
+    block-height = "50"
+    role = "light"

--- a/compositions/cluster-k8s/tc-005-light-das-past/40-40-20-100/320-100mib-100ms.toml
+++ b/compositions/cluster-k8s/tc-005-light-das-past/40-40-20-100/320-100mib-100ms.toml
@@ -1,0 +1,108 @@
+[metadata]
+  name = "005-light-das-past-40-40-20-100-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "005-light-das-past"
+  total_instances = 200
+  builder = "docker:generic"
+  runner = "cluster:k8s"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "20"
+  persistent-peers = "10"
+  submit-times = "52"
+  msg-size = "100000"
+  validator = "40"
+  bridge = "40"
+  full = "20"
+  light = "100"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 40
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "100"
+    bandwidth = "320Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 40
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "100"
+    bandwidth = "320Mib"
+    block-height = "30"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 20
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "100"
+    bandwidth = "320Mib"
+    block-height = "50"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "1Gi"
+    cpu = "1500m"
+  [groups.instances]
+    count = 100
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "100"
+    bandwidth = "100Mib"
+    block-height = "50"
+    role = "light"

--- a/compositions/cluster-k8s/tc-005-light-das-past/40-40-20-100/320-100mib-200ms.toml
+++ b/compositions/cluster-k8s/tc-005-light-das-past/40-40-20-100/320-100mib-200ms.toml
@@ -1,0 +1,108 @@
+[metadata]
+  name = "005-light-das-past-40-40-20-100-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "005-light-das-past"
+  total_instances = 200
+  builder = "docker:generic"
+  runner = "cluster:k8s"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "20"
+  persistent-peers = "10"
+  submit-times = "52"
+  msg-size = "100000"
+  validator = "40"
+  bridge = "40"
+  full = "20"
+  light = "100"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 40
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "200"
+    bandwidth = "320Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 40
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "200"
+    bandwidth = "320Mib"
+    block-height = "30"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 20
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "200"
+    bandwidth = "320Mib"
+    block-height = "50"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "1Gi"
+    cpu = "1500m"
+  [groups.instances]
+    count = 100
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "200"
+    bandwidth = "100Mib"
+    block-height = "50"
+    role = "light"


### PR DESCRIPTION
- Compositions for K8s For TC-005: Light node das past headers
- Kick-start sanity checkers dir for upcoming CI/CD pipeline with testground

Closes #62 