### PR TITLE
feat: implementation of TC#004

### DIFF
--- a/compositions/local-docker/004-full-light-past-12.toml
+++ b/compositions/local-docker/004-full-light-past-12.toml
@@ -1,0 +1,108 @@
+[metadata]
+  name = "004-full-light-past-3-3-3-3-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "004-full-light-past"
+  total_instances = 12
+  builder = "docker:generic"
+  runner = "local:docker"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "30"
+  persistent-peers = "3"
+  submit-times = "42"
+  msg-size = "100000"
+  validator = "3"
+  bridge = "3"
+  full = "3"
+  light = "3"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = ""
+    cpu = ""
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = ""
+    cpu = ""
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "30"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = ""
+    cpu = ""
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "40"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = ""
+    cpu = ""
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "100Mib"
+    block-height = "40"
+    role = "light"

--- a/main.go
+++ b/main.go
@@ -6,10 +6,11 @@ import (
 )
 
 var testcases = map[string]interface{}{
-	"001-val-large-txs":  run.InitializedTestCaseFn(tests.ValSubmitLargeTxs),
-	"002-da-sync":        run.InitializedTestCaseFn(tests.SyncNodes),
-	"003-full-sync-past": run.InitializedTestCaseFn(tests.FullSyncPast),
-	"005-light-das-past": run.InitializedTestCaseFn(tests.LightDasPast),
+	"001-val-large-txs":   run.InitializedTestCaseFn(tests.ValSubmitLargeTxs),
+	"002-da-sync":         run.InitializedTestCaseFn(tests.SyncNodes),
+	"003-full-sync-past":  run.InitializedTestCaseFn(tests.FullSyncPast),
+	"004-full-light-past": run.InitializedTestCaseFn(tests.FullLightSyncPast),
+	"005-light-das-past":  run.InitializedTestCaseFn(tests.LightDasPast),
 }
 
 func main() {

--- a/manifest.toml
+++ b/manifest.toml
@@ -63,6 +63,23 @@ instances = { min = 4, max = 3000, default = 12 }
     role = { type = "string" }
 
 [[testcases]]
+name = "004-full-light-past"
+instances = { min = 4, max = 3000, default = 12 }
+    [testcases.params]
+    execution-time = { type = "int" }
+    latency = { type = "int", default = 0}
+    bandwidth = { type = "string", default = "256Mib"}
+    validator = { type = "int", default = 3}
+    persistent-peers = { type = "int", default = 3}
+    submit-times = { type = "int", default = 4}
+    msg-size = { type = "int", default = 10000}
+    bridge = { type = "int", default = 3}
+    full = { type = "int", default = 3}
+    light = { type = "int", default = 3}
+    block-height = { type = "int" }
+    role = { type = "string" }
+
+[[testcases]]
 name = "005-light-das-past"
 instances = { min = 4, max = 3000, default = 12 }
     [testcases.params]

--- a/tests/tc-004-full-light-past.go
+++ b/tests/tc-004-full-light-past.go
@@ -1,0 +1,30 @@
+package tests
+
+import (
+	nodesync "github.com/celestiaorg/test-infra/tests/node-sync"
+	syncpast "github.com/celestiaorg/test-infra/tests/sync-past"
+
+	"github.com/testground/sdk-go/run"
+	"github.com/testground/sdk-go/runtime"
+)
+
+// Test-Case #004 - Full and Light nodes are syncing past headers faster then validators produce new ones
+// Description is in docs/test-plans/001-Big-Blocks/test-cases
+func FullLightSyncPast(runenv *runtime.RunEnv, initCtx *run.InitContext) (err error) {
+	switch runenv.StringParam("role") {
+	case "validator":
+		err = nodesync.RunAppValidator(runenv, initCtx)
+	case "bridge":
+		err = syncpast.RunBridgeNode(runenv, initCtx)
+	case "full":
+		err = syncpast.RunFullNode(runenv, initCtx)
+	case "light":
+		err = syncpast.RunLightNode(runenv, initCtx)
+	}
+
+	if err != nil {
+		return err
+	}
+	runenv.RecordSuccess()
+	return nil
+}


### PR DESCRIPTION
Full and Light nodes are syncing past headers faster then validators produce new ones
- added local:docker composition
- update manifest to TC-004

Closes #63