### PR TITLE
feat: add sanity compositions for pfd/gsbn

### DIFF
--- a/compositions/cluster-k8s/sanity/gsbn-8.toml
+++ b/compositions/cluster-k8s/sanity/gsbn-8.toml
@@ -1,0 +1,109 @@
+[metadata]
+  name = "get-shares-by-namespace-3-3-1-1-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "get-shares-by-namespace"
+  total_instances = 8
+  builder = "docker:generic"
+  runner = "cluster:k8s"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "10"
+  persistent-peers = "3"
+  submit-times = "12"
+  namespace-id = "1"
+  msg-size = "100000"
+  validator = "3"
+  bridge = "3"
+  full = "1"
+  light = "1"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "4500m"
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "4500m"
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "5"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "5"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "2Gi"
+    cpu = "1500m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "100Mib"
+    block-height = "5"
+    role = "light"

--- a/compositions/cluster-k8s/sanity/pfd-8.toml
+++ b/compositions/cluster-k8s/sanity/pfd-8.toml
@@ -1,0 +1,109 @@
+[metadata]
+  name = "pay-for-data-3-3-1-1-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "pay-for-data"
+  total_instances = 8
+  builder = "docker:generic"
+  runner = "cluster:k8s"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "10"
+  persistent-peers = "3"
+  submit-times = "12"
+  namespace-id = "1"
+  msg-size = "100000"
+  validator = "3"
+  bridge = "3"
+  full = "1"
+  light = "1"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "4500m"
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "4500m"
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "5"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "5"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "2Gi"
+    cpu = "1500m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "100Mib"
+    block-height = "5"
+    role = "light"

--- a/tests/helpers/common/data.go
+++ b/tests/helpers/common/data.go
@@ -62,6 +62,7 @@ func SubmitData(ctx context.Context, runenv *runtime.RunEnv, nd *nodebuilder.Nod
 
 // CheckSharesByNamespace accepts an expected namespace.ID and data that was submitted.
 // Next, it verifies the data against the received shares of a block from a user-specified extended header
+// by comparing length of each
 func CheckSharesByNamespace(ctx context.Context, nd *nodebuilder.Node, nid namespace.ID, eh *header.ExtendedHeader, expectedData []byte) error {
 	shares, err := nd.ShareServ.GetSharesByNamespace(ctx, eh.DAH, nid)
 	if err != nil {
@@ -69,8 +70,7 @@ func CheckSharesByNamespace(ctx context.Context, nd *nodebuilder.Node, nid names
 	}
 
 	allConcatData := bytes.Join(shares, nid)
-
-	if bytes.Compare(allConcatData, expectedData) >= 0 {
+	if len(allConcatData) >= len(expectedData) {
 		return nil
 	}
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
After debug sessions, I've found out that OOMKilled error was causing RPC error unavail to pop up during pfd/gsbn calls from node 

- Added 2 compositions to sanity check for `cluster:k8s` 
- Fixed the data comparisons based on length of the data vs all shares in the nid
- Should be reviewed after #123 

Closes #118 
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
