### PR TITLE
chore: adapt block reconstruction to reflect EKS setup

### DIFF
--- a/compositions/cluster-k8s/block-reconstruction/32-square-size/1-full-node.toml
+++ b/compositions/cluster-k8s/block-reconstruction/32-square-size/1-full-node.toml
@@ -5,7 +5,7 @@
 [global]
   plan = "celestia"
   case = "reconstruction"
-  total_instances = 358
+  total_instances = 357
   builder = "docker:generic"
   runner = "cluster:k8s"
   disable_metrics = false
@@ -17,7 +17,7 @@
   msg-size = "10000"
   validator = "3"
   bridge = "3"
-  full = "2"
+  full = "1"
   light = "350"
 
 [[groups]]
@@ -70,7 +70,7 @@
     memory = "16Gi"
     cpu = "10"
   [groups.instances]
-    count = 2
+    count = 1
     percentage = 0.0
   [groups.build_config]
     build_base_image = "golang:1.19.1"

--- a/compositions/cluster-k8s/block-reconstruction/32-square-size/2-full-nodes.toml
+++ b/compositions/cluster-k8s/block-reconstruction/32-square-size/2-full-nodes.toml
@@ -5,18 +5,18 @@
 [global]
   plan = "celestia"
   case = "reconstruction"
-  total_instances = 362
+  total_instances = 358
   builder = "docker:generic"
   runner = "cluster:k8s"
   disable_metrics = false
 
 [global.run.test_params]
   execution-time = "20"
-  persistent-peers = "5"
+  persistent-peers = "3"
   submit-times = "21"
   msg-size = "10000"
-  validator = "5"
-  bridge = "5"
+  validator = "3"
+  bridge = "3"
   full = "2"
   light = "350"
 
@@ -27,7 +27,7 @@
     memory = "4Gi"
     cpu = "3000m"
   [groups.instances]
-    count = 5
+    count = 3
     percentage = 0.0
   [groups.build_config]
     build_base_image = "golang:1.19.1"
@@ -48,7 +48,7 @@
     memory = "4Gi"
     cpu = "3000m"
   [groups.instances]
-    count = 5
+    count = 3
     percentage = 0.0
   [groups.build_config]
     build_base_image = "golang:1.19.1"
@@ -67,7 +67,7 @@
   id = "fulls"
   builder = "docker:generic"
  [groups.resources]
-    memory = "128Gi"
+    memory = "16Gi"
     cpu = "16000m"
   [groups.instances]
     count = 2

--- a/compositions/cluster-k8s/block-reconstruction/32-square-size/3-full-nodes.toml
+++ b/compositions/cluster-k8s/block-reconstruction/32-square-size/3-full-nodes.toml
@@ -5,18 +5,18 @@
 [global]
   plan = "celestia"
   case = "reconstruction"
-  total_instances = 363
+  total_instances = 359
   builder = "docker:generic"
   runner = "cluster:k8s"
   disable_metrics = false
 
 [global.run.test_params]
   execution-time = "20"
-  persistent-peers = "5"
+  persistent-peers = "3"
   submit-times = "21"
   msg-size = "10000"
-  validator = "5"
-  bridge = "5"
+  validator = "3"
+  bridge = "3"
   full = "3"
   light = "350"
 
@@ -27,7 +27,7 @@
     memory = "4Gi"
     cpu = "3000m"
   [groups.instances]
-    count = 5
+    count = 3
     percentage = 0.0
   [groups.build_config]
     build_base_image = "golang:1.19.1"
@@ -48,7 +48,7 @@
     memory = "4Gi"
     cpu = "3000m"
   [groups.instances]
-    count = 5
+    count = 3
     percentage = 0.0
   [groups.build_config]
     build_base_image = "golang:1.19.1"
@@ -67,7 +67,7 @@
   id = "fulls"
   builder = "docker:generic"
  [groups.resources]
-    memory = "64Gi"
+    memory = "16Gi"
     cpu = "12000m"
   [groups.instances]
     count = 3

--- a/compositions/cluster-k8s/block-reconstruction/32-square-size/4-full-nodes.toml
+++ b/compositions/cluster-k8s/block-reconstruction/32-square-size/4-full-nodes.toml
@@ -5,18 +5,18 @@
 [global]
   plan = "celestia"
   case = "reconstruction"
-  total_instances = 364
+  total_instances = 360
   builder = "docker:generic"
   runner = "cluster:k8s"
   disable_metrics = false
 
 [global.run.test_params]
   execution-time = "20"
-  persistent-peers = "5"
+  persistent-peers = "3"
   submit-times = "21"
   msg-size = "10000"
-  validator = "5"
-  bridge = "5"
+  validator = "3"
+  bridge = "3"
   full = "4"
   light = "350"
 
@@ -27,7 +27,7 @@
     memory = "4Gi"
     cpu = "3000m"
   [groups.instances]
-    count = 5
+    count = 3
     percentage = 0.0
   [groups.build_config]
     build_base_image = "golang:1.19.1"
@@ -48,7 +48,7 @@
     memory = "4Gi"
     cpu = "3000m"
   [groups.instances]
-    count = 5
+    count = 3
     percentage = 0.0
   [groups.build_config]
     build_base_image = "golang:1.19.1"
@@ -67,7 +67,7 @@
   id = "fulls"
   builder = "docker:generic"
  [groups.resources]
-    memory = "32Gi"
+    memory = "8Gi"
     cpu = "8000m"
   [groups.instances]
     count = 4

--- a/compositions/cluster-k8s/block-reconstruction/64-square-size/1-full-node.toml
+++ b/compositions/cluster-k8s/block-reconstruction/64-square-size/1-full-node.toml
@@ -1,113 +1,113 @@
 [metadata]
-  name = "reconstruction"
-  author = "Bidon15"
+name = "reconstruction"
+author = "Bidon15"
 
 [global]
-  plan = "celestia"
-  case = "reconstruction"
-  total_instances = 1419
-  builder = "docker:generic"
-  runner = "cluster:k8s"
-  disable_metrics = false
-  [global.run]
-    artifact = ""
-    [global.run.test_params]
-      bridge = "3"
-      execution-time = "20"
-      full = "1"
-      light = "1412"
-      msg-size = "50000"
-      persistent-peers = "3"
-      submit-times = "20"
-      validator = "3"
+plan = "celestia"
+case = "reconstruction"
+total_instances = 1433
+builder = "docker:generic"
+runner = "cluster:k8s"
+disable_metrics = false
+[global.run]
+artifact = ""
+[global.run.test_params]
+bridge = "10"
+execution-time = "20"
+full = "1"
+light = "1412"
+msg-size = "15000"
+persistent-peers = "10"
+submit-times = "20"
+validator = "10"
 
 [[groups]]
-  id = "validators"
-  builder = "docker:generic"
-  [groups.resources]
-    memory = "4Gi"
-    cpu = "2000m"
-  [groups.instances]
-    count = 3
-    percentage = 0.0
-  [groups.build_config]
-    build_base_image = "golang:1.19.1"
-    enable_go_build_cache = true
-    enabled = true
-    go_version = "1.19"
-  [groups.build]
-  [groups.run]
-    artifact = ""
-    [groups.run.test_params]
-      bandwidth = "256Mib"
-      latency = "50"
-      role = "validator"
+id = "validators"
+builder = "docker:generic"
+[groups.resources]
+memory = "4Gi"
+cpu = "2000m"
+[groups.instances]
+count = 10
+percentage = 0.0
+[groups.build_config]
+build_base_image = "golang:1.19.1"
+enable_go_build_cache = true
+enabled = true
+go_version = "1.19"
+[groups.build]
+[groups.run]
+artifact = ""
+[groups.run.test_params]
+bandwidth = "256Mib"
+latency = "50"
+role = "validator"
 
 [[groups]]
-  id = "bridges"
-  builder = "docker:generic"
-  [groups.resources]
-    memory = "4Gi"
-    cpu = "2000m"
-  [groups.instances]
-    count = 3
-    percentage = 0.0
-  [groups.build_config]
-    build_base_image = "golang:1.19.1"
-    enable_go_build_cache = true
-    enabled = true
-    go_version = "1.19"
-  [groups.build]
-  [groups.run]
-    artifact = ""
-    [groups.run.test_params]
-      bandwidth = "256Mib"
-      block-height = "5"
-      latency = "50"
-      role = "bridge"
+id = "bridges"
+builder = "docker:generic"
+[groups.resources]
+memory = "4Gi"
+cpu = "2000m"
+[groups.instances]
+count = 10
+percentage = 0.0
+[groups.build_config]
+build_base_image = "golang:1.19.1"
+enable_go_build_cache = true
+enabled = true
+go_version = "1.19"
+[groups.build]
+[groups.run]
+artifact = ""
+[groups.run.test_params]
+bandwidth = "256Mib"
+block-height = "5"
+latency = "50"
+role = "bridge"
 
 [[groups]]
-  id = "fulls"
-  builder = "docker:generic"
-  [groups.resources]
-    memory = "16Gi"
-    cpu = "8"
-  [groups.instances]
-    count = 1
-    percentage = 0.0
-  [groups.build_config]
-    build_base_image = "golang:1.19.1"
-    enable_go_build_cache = true
-    enabled = true
-    go_version = "1.19"
-  [groups.build]
-  [groups.run]
-    artifact = ""
-    [groups.run.test_params]
-      bandwidth = "256Mib"
-      block-height = "5"
-      latency = "50"
-      role = "full"
+id = "fulls"
+builder = "docker:generic"
+[groups.resources]
+memory = "8Gi"
+cpu = "8"
+[groups.instances]
+count = 1
+percentage = 0.0
+[groups.build_config]
+build_base_image = "golang:1.19.1"
+enable_go_build_cache = true
+enabled = true
+go_version = "1.19"
+[groups.build]
+[groups.run]
+artifact = ""
+[groups.run.test_params]
+bandwidth = "256Mib"
+block-height = "5"
+latency = "50"
+role = "full"
 
 [[groups]]
-  id = "lights"
-  builder = "docker:generic"
-  [groups.resources]
-    memory = "300Mi"
-    cpu = "150m"
-  [groups.instances]
-    count = 1412
-    percentage = 0.0
-  [groups.build_config]
-    build_base_image = "golang:1.19.1"
-    enable_go_build_cache = true
-    enabled = true
-    go_version = "1.19"
-  [groups.build]
-  [groups.run]
-    artifact = ""
-    [groups.run.test_params]
-      bandwidth = "256Mib"
-      block-height = "5"
-      latency = "50"
-      role = "light"
+id = "lights"
+builder = "docker:generic"
+[groups.resources]
+memory = "300Mi"
+cpu = "150m"
+[groups.instances]
+count = 1412
+percentage = 0.0
+[groups.build_config]
+build_base_image = "golang:1.19.1"
+enable_go_build_cache = true
+enabled = true
+go_version = "1.19"
+[groups.build]
+[groups.run]
+artifact = ""
+[groups.run.test_params]
+bandwidth = "256Mib"
+block-height = "5"
+latency = "50"
+role = "light"

--- a/compositions/cluster-k8s/block-reconstruction/64-square-size/1-full-node.toml
+++ b/compositions/cluster-k8s/block-reconstruction/64-square-size/1-full-node.toml
@@ -13,12 +13,12 @@
     artifact = ""
     [global.run.test_params]
       bridge = "3"
-      execution-time = "40"
+      execution-time = "20"
       full = "1"
       light = "1412"
-      msg-size = "100000"
+      msg-size = "50000"
       persistent-peers = "3"
-      submit-times = "60"
+      submit-times = "20"
       validator = "3"
 
 [[groups]]

--- a/compositions/cluster-k8s/block-reconstruction/64-square-size/10-full-nodes.toml
+++ b/compositions/cluster-k8s/block-reconstruction/64-square-size/10-full-nodes.toml
@@ -5,7 +5,7 @@
 [global]
   plan = "celestia"
   case = "reconstruction"
-  total_instances = 1433
+  total_instances = 1442
   builder = "docker:generic"
   runner = "cluster:k8s"
   disable_metrics = false
@@ -14,7 +14,7 @@
     [global.run.test_params]
       bridge = "10"
       execution-time = "20"
-      full = "1"
+      full = "10"
       light = "1412"
       msg-size = "15000"
       persistent-peers = "10"
@@ -73,7 +73,7 @@
     memory = "8Gi"
     cpu = "8"
   [groups.instances]
-    count = 1
+    count = 10
     percentage = 0.0
   [groups.build_config]
     build_base_image = "golang:1.19.1"

--- a/compositions/cluster-k8s/block-reconstruction/64-square-size/2-full-nodes.toml
+++ b/compositions/cluster-k8s/block-reconstruction/64-square-size/2-full-nodes.toml
@@ -13,12 +13,12 @@
     artifact = ""
     [global.run.test_params]
       bridge = "3"
-      execution-time = "40"
+      execution-time = "20"
       full = "2"
       light = "1412"
-      msg-size = "100000"
+      msg-size = "50000"
       persistent-peers = "3"
-      submit-times = "60"
+      submit-times = "20"
       validator = "3"
 
 [[groups]]

--- a/compositions/cluster-k8s/block-reconstruction/64-square-size/2-full-nodes.toml
+++ b/compositions/cluster-k8s/block-reconstruction/64-square-size/2-full-nodes.toml
@@ -5,109 +5,109 @@
 [global]
   plan = "celestia"
   case = "reconstruction"
-  total_instances = 1420
+  total_instances = 1434
   builder = "docker:generic"
   runner = "cluster:k8s"
   disable_metrics = false
   [global.run]
     artifact = ""
     [global.run.test_params]
-      bridge = "3"
+      bridge = "10"
       execution-time = "20"
       full = "2"
       light = "1412"
-      msg-size = "50000"
-      persistent-peers = "3"
+      msg-size = "15000"
+      persistent-peers = "10"
       submit-times = "20"
-      validator = "3"
+      validator = "10"
 
 [[groups]]
-  id = "validators"
-  builder = "docker:generic"
-  [groups.resources]
-    memory = "4Gi"
-    cpu = "2000m"
-  [groups.instances]
-    count = 3
-    percentage = 0.0
-  [groups.build_config]
-    build_base_image = "golang:1.19.1"
-    enable_go_build_cache = true
-    enabled = true
-    go_version = "1.19"
-  [groups.build]
-  [groups.run]
-    artifact = ""
-    [groups.run.test_params]
-      bandwidth = "256Mib"
-      latency = "50"
-      role = "validator"
+id = "validators"
+builder = "docker:generic"
+[groups.resources]
+memory = "4Gi"
+cpu = "2000m"
+[groups.instances]
+count = 10
+percentage = 0.0
+[groups.build_config]
+build_base_image = "golang:1.19.1"
+enable_go_build_cache = true
+enabled = true
+go_version = "1.19"
+[groups.build]
+[groups.run]
+artifact = ""
+[groups.run.test_params]
+bandwidth = "256Mib"
+latency = "50"
+role = "validator"
 
 [[groups]]
-  id = "bridges"
-  builder = "docker:generic"
-  [groups.resources]
-    memory = "4Gi"
-    cpu = "2000m"
-  [groups.instances]
-    count = 3
-    percentage = 0.0
-  [groups.build_config]
-    build_base_image = "golang:1.19.1"
-    enable_go_build_cache = true
-    enabled = true
-    go_version = "1.19"
-  [groups.build]
-  [groups.run]
-    artifact = ""
-    [groups.run.test_params]
-      bandwidth = "256Mib"
-      block-height = "5"
-      latency = "50"
-      role = "bridge"
+id = "bridges"
+builder = "docker:generic"
+[groups.resources]
+memory = "4Gi"
+cpu = "2000m"
+[groups.instances]
+count = 10
+percentage = 0.0
+[groups.build_config]
+build_base_image = "golang:1.19.1"
+enable_go_build_cache = true
+enabled = true
+go_version = "1.19"
+[groups.build]
+[groups.run]
+artifact = ""
+[groups.run.test_params]
+bandwidth = "256Mib"
+block-height = "5"
+latency = "50"
+role = "bridge"
 
 [[groups]]
-  id = "fulls"
-  builder = "docker:generic"
-  [groups.resources]
-    memory = "16Gi"
-    cpu = "8"
-  [groups.instances]
-    count = 2
-    percentage = 0.0
-  [groups.build_config]
-    build_base_image = "golang:1.19.1"
-    enable_go_build_cache = true
-    enabled = true
-    go_version = "1.19"
-  [groups.build]
-  [groups.run]
-    artifact = ""
-    [groups.run.test_params]
-      bandwidth = "256Mib"
-      block-height = "5"
-      latency = "50"
-      role = "full"
+id = "fulls"
+builder = "docker:generic"
+[groups.resources]
+memory = "8Gi"
+cpu = "8"
+[groups.instances]
+count = 2
+percentage = 0.0
+[groups.build_config]
+build_base_image = "golang:1.19.1"
+enable_go_build_cache = true
+enabled = true
+go_version = "1.19"
+[groups.build]
+[groups.run]
+artifact = ""
+[groups.run.test_params]
+bandwidth = "256Mib"
+block-height = "5"
+latency = "50"
+role = "full"
 
 [[groups]]
-  id = "lights"
-  builder = "docker:generic"
-  [groups.resources]
-    memory = "300Mi"
-    cpu = "150m"
-  [groups.instances]
-    count = 1412
-    percentage = 0.0
-  [groups.build_config]
-    build_base_image = "golang:1.19.1"
-    enable_go_build_cache = true
-    enabled = true
-    go_version = "1.19"
-  [groups.build]
-  [groups.run]
-    artifact = ""
-    [groups.run.test_params]
-      bandwidth = "256Mib"
-      block-height = "5"
-      latency = "50"
-      role = "light"
+id = "lights"
+builder = "docker:generic"
+[groups.resources]
+memory = "300Mi"
+cpu = "150m"
+[groups.instances]
+count = 1412
+percentage = 0.0
+[groups.build_config]
+build_base_image = "golang:1.19.1"
+enable_go_build_cache = true
+enabled = true
+go_version = "1.19"
+[groups.build]
+[groups.run]
+artifact = ""
+[groups.run.test_params]
+bandwidth = "256Mib"
+block-height = "5"
+latency = "50"
+role = "light"

--- a/compositions/cluster-k8s/block-reconstruction/64-square-size/2-full-nodes.toml
+++ b/compositions/cluster-k8s/block-reconstruction/64-square-size/2-full-nodes.toml
@@ -22,92 +22,92 @@
       validator = "10"
 
 [[groups]]
-id = "validators"
-builder = "docker:generic"
-[groups.resources]
-memory = "4Gi"
-cpu = "2000m"
-[groups.instances]
-count = 10
-percentage = 0.0
-[groups.build_config]
-build_base_image = "golang:1.19.1"
-enable_go_build_cache = true
-enabled = true
-go_version = "1.19"
-[groups.build]
-[groups.run]
-artifact = ""
-[groups.run.test_params]
-bandwidth = "256Mib"
-latency = "50"
-role = "validator"
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "2000m"
+  [groups.instances]
+    count = 10
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    artifact = ""
+    [groups.run.test_params]
+      bandwidth = "256Mib"
+      latency = "50"
+      role = "validator"
 
 [[groups]]
-id = "bridges"
-builder = "docker:generic"
-[groups.resources]
-memory = "4Gi"
-cpu = "2000m"
-[groups.instances]
-count = 10
-percentage = 0.0
-[groups.build_config]
-build_base_image = "golang:1.19.1"
-enable_go_build_cache = true
-enabled = true
-go_version = "1.19"
-[groups.build]
-[groups.run]
-artifact = ""
-[groups.run.test_params]
-bandwidth = "256Mib"
-block-height = "5"
-latency = "50"
-role = "bridge"
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "2000m"
+  [groups.instances]
+    count = 10
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    artifact = ""
+    [groups.run.test_params]
+      bandwidth = "256Mib"
+      block-height = "5"
+      latency = "50"
+      role = "bridge"
 
 [[groups]]
-id = "fulls"
-builder = "docker:generic"
-[groups.resources]
-memory = "8Gi"
-cpu = "8"
-[groups.instances]
-count = 2
-percentage = 0.0
-[groups.build_config]
-build_base_image = "golang:1.19.1"
-enable_go_build_cache = true
-enabled = true
-go_version = "1.19"
-[groups.build]
-[groups.run]
-artifact = ""
-[groups.run.test_params]
-bandwidth = "256Mib"
-block-height = "5"
-latency = "50"
-role = "full"
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "8Gi"
+    cpu = "8"
+  [groups.instances]
+    count = 2
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    artifact = ""
+    [groups.run.test_params]
+      bandwidth = "256Mib"
+      block-height = "5"
+      latency = "50"
+      role = "full"
 
 [[groups]]
-id = "lights"
-builder = "docker:generic"
-[groups.resources]
-memory = "300Mi"
-cpu = "150m"
-[groups.instances]
-count = 1412
-percentage = 0.0
-[groups.build_config]
-build_base_image = "golang:1.19.1"
-enable_go_build_cache = true
-enabled = true
-go_version = "1.19"
-[groups.build]
-[groups.run]
-artifact = ""
-[groups.run.test_params]
-bandwidth = "256Mib"
-block-height = "5"
-latency = "50"
-role = "light"
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "300Mi"
+    cpu = "150m"
+  [groups.instances]
+    count = 1412
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    artifact = ""
+    [groups.run.test_params]
+      bandwidth = "256Mib"
+      block-height = "5"
+      latency = "50"
+      role = "light"

--- a/compositions/cluster-k8s/block-reconstruction/64-square-size/3-full-nodes.toml
+++ b/compositions/cluster-k8s/block-reconstruction/64-square-size/3-full-nodes.toml
@@ -5,21 +5,21 @@
 [global]
   plan = "celestia"
   case = "reconstruction"
-  total_instances = 1421
+  total_instances = 1425
   builder = "docker:generic"
   runner = "cluster:k8s"
   disable_metrics = false
   [global.run]
     artifact = ""
     [global.run.test_params]
-      bridge = "3"
+      bridge = "5"
       execution-time = "20"
       full = "3"
       light = "1412"
-      msg-size = "50000"
-      persistent-peers = "3"
+      msg-size = "30000"
+      persistent-peers = "5"
       submit-times = "20"
-      validator = "3"
+      validator = "5"
 
 [[groups]]
   id = "validators"
@@ -28,7 +28,7 @@
     memory = "4Gi"
     cpu = "2000m"
   [groups.instances]
-    count = 3
+    count = 5
     percentage = 0.0
   [groups.build_config]
     build_base_image = "golang:1.19.1"
@@ -48,9 +48,9 @@
   builder = "docker:generic"
   [groups.resources]
     memory = "4Gi"
-    cpu = "2000m"
+    cpu = "4000m"
   [groups.instances]
-    count = 3
+    count = 5
     percentage = 0.0
   [groups.build_config]
     build_base_image = "golang:1.19.1"
@@ -70,7 +70,7 @@
   id = "fulls"
   builder = "docker:generic"
   [groups.resources]
-    memory = "10Gi"
+    memory = "8Gi"
     cpu = "8"
   [groups.instances]
     count = 3

--- a/compositions/cluster-k8s/block-reconstruction/64-square-size/3-full-nodes.toml
+++ b/compositions/cluster-k8s/block-reconstruction/64-square-size/3-full-nodes.toml
@@ -13,12 +13,12 @@
     artifact = ""
     [global.run.test_params]
       bridge = "3"
-      execution-time = "40"
+      execution-time = "20"
       full = "3"
       light = "1412"
-      msg-size = "100000"
+      msg-size = "50000"
       persistent-peers = "3"
-      submit-times = "60"
+      submit-times = "20"
       validator = "3"
 
 [[groups]]
@@ -70,7 +70,7 @@
   id = "fulls"
   builder = "docker:generic"
   [groups.resources]
-    memory = "16Gi"
+    memory = "10Gi"
     cpu = "8"
   [groups.instances]
     count = 3

--- a/compositions/cluster-k8s/block-reconstruction/64-square-size/4-full-nodes.toml
+++ b/compositions/cluster-k8s/block-reconstruction/64-square-size/4-full-nodes.toml
@@ -5,21 +5,21 @@
 [global]
   plan = "celestia"
   case = "reconstruction"
-  total_instances = 1422
+  total_instances = 1436
   builder = "docker:generic"
   runner = "cluster:k8s"
   disable_metrics = false
   [global.run]
     artifact = ""
     [global.run.test_params]
-      bridge = "3"
+      bridge = "10"
       execution-time = "20"
       full = "4"
       light = "1412"
-      msg-size = "50000"
-      persistent-peers = "3"
+      msg-size = "15000"
+      persistent-peers = "10"
       submit-times = "20"
-      validator = "3"
+      validator = "10"
 
 [[groups]]
   id = "validators"
@@ -28,7 +28,7 @@
     memory = "4Gi"
     cpu = "2000m"
   [groups.instances]
-    count = 3
+    count = 10
     percentage = 0.0
   [groups.build_config]
     build_base_image = "golang:1.19.1"
@@ -50,7 +50,7 @@
     memory = "4Gi"
     cpu = "2000m"
   [groups.instances]
-    count = 3
+    count = 10
     percentage = 0.0
   [groups.build_config]
     build_base_image = "golang:1.19.1"

--- a/compositions/cluster-k8s/block-reconstruction/64-square-size/4-full-nodes.toml
+++ b/compositions/cluster-k8s/block-reconstruction/64-square-size/4-full-nodes.toml
@@ -13,12 +13,12 @@
     artifact = ""
     [global.run.test_params]
       bridge = "3"
-      execution-time = "40"
+      execution-time = "20"
       full = "4"
       light = "1412"
-      msg-size = "100000"
+      msg-size = "50000"
       persistent-peers = "3"
-      submit-times = "60"
+      submit-times = "20"
       validator = "3"
 
 [[groups]]
@@ -70,7 +70,7 @@
   id = "fulls"
   builder = "docker:generic"
   [groups.resources]
-    memory = "16Gi"
+    memory = "8Gi"
     cpu = "8"
   [groups.instances]
     count = 4

--- a/compositions/cluster-k8s/sanity/gsbn-8.toml
+++ b/compositions/cluster-k8s/sanity/gsbn-8.toml
@@ -1,0 +1,109 @@
+[metadata]
+  name = "get-shares-by-namespace-3-3-1-1-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "get-shares-by-namespace"
+  total_instances = 8
+  builder = "docker:generic"
+  runner = "cluster:k8s"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "10"
+  persistent-peers = "3"
+  submit-times = "12"
+  namespace-id = "1"
+  msg-size = "100000"
+  validator = "3"
+  bridge = "3"
+  full = "1"
+  light = "1"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "4500m"
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "4500m"
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "5"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "5"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "2Gi"
+    cpu = "1500m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "100Mib"
+    block-height = "5"
+    role = "light"

--- a/compositions/cluster-k8s/sanity/pfd-8.toml
+++ b/compositions/cluster-k8s/sanity/pfd-8.toml
@@ -1,0 +1,109 @@
+[metadata]
+  name = "pay-for-data-3-3-1-1-set"
+  author = "Bidon15"
+
+[global]
+  plan = "celestia"
+  case = "pay-for-data"
+  total_instances = 8
+  builder = "docker:generic"
+  runner = "cluster:k8s"
+  disable_metrics = false
+
+[global.run.test_params]
+  execution-time = "10"
+  persistent-peers = "3"
+  submit-times = "12"
+  namespace-id = "1"
+  msg-size = "100000"
+  validator = "3"
+  bridge = "3"
+  full = "1"
+  light = "1"
+
+[[groups]]
+  id = "validators"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "4500m"
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    role = "validator"
+
+[[groups]]
+  id = "bridges"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "4500m"
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "5"
+    role = "bridge"
+
+[[groups]]
+  id = "fulls"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "4Gi"
+    cpu = "3"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "256Mib"
+    block-height = "5"
+    role = "full"
+
+[[groups]]
+  id = "lights"
+  builder = "docker:generic"
+  [groups.resources]
+    memory = "2Gi"
+    cpu = "1500m"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.build_config]
+    build_base_image = "golang:1.19.1"
+    enable_go_build_cache = true
+    enabled = true
+    go_version = "1.19"
+  [groups.build]
+  [groups.run]
+    [groups.run.test_params]
+    latency = "0"
+    bandwidth = "100Mib"
+    block-height = "5"
+    role = "light"

--- a/tests/helpers/common/data.go
+++ b/tests/helpers/common/data.go
@@ -62,6 +62,7 @@ func SubmitData(ctx context.Context, runenv *runtime.RunEnv, nd *nodebuilder.Nod
 
 // CheckSharesByNamespace accepts an expected namespace.ID and data that was submitted.
 // Next, it verifies the data against the received shares of a block from a user-specified extended header
+// by comparing length of each
 func CheckSharesByNamespace(ctx context.Context, nd *nodebuilder.Node, nid namespace.ID, eh *header.ExtendedHeader, expectedData []byte) error {
 	shares, err := nd.ShareServ.GetSharesByNamespace(ctx, eh.DAH, nid)
 	if err != nil {
@@ -69,8 +70,7 @@ func CheckSharesByNamespace(ctx context.Context, nd *nodebuilder.Node, nid names
 	}
 
 	allConcatData := bytes.Join(shares, nid)
-
-	if bytes.Compare(allConcatData, expectedData) >= 0 {
+	if len(allConcatData) >= len(expectedData) {
 		return nil
 	}
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
These adaptations were implemented during execution of #96 

Currently, our instances setup for K8s can't support more than 8Gb of RAM per pod, so we decreased the figures for all compositions

Other notes:

- Added 10 bridges instead of 3/5 for sq sz 64
- Created a new composition with 10 full nodes to reconstruct a block from 1412 Light Nodes


Closes #126 
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
