### PR TITLE
fix: Error logs to stderr stream

### DIFF
--- a/testkit/appkit/app.go
+++ b/testkit/appkit/app.go
@@ -198,7 +198,8 @@ func (ak *AppKit) GetNodeId() (string, error) {
 func (ak *AppKit) StartNode(loglvl string) error {
 	ak.Cmd.ResetFlags()
 
-	ak.Cmd.SetErr(os.Stdout)
+	// SetErr: send the error logs to stderr stream.
+	ak.Cmd.SetErr(os.Stderr)
 	ak.Cmd.SetArgs(
 		[]string{
 			"start",


### PR DESCRIPTION
## Overview

Hello team!

Tiny change, as a best practice, I've moved the errors stream to `stderr` instead of using the `stdout` which is the default log stream but not for errors. I realised that we were using the same stream for both use cases.

Was it set to `stdout` in purpose?

Thanks in advance! 🚀 

## Checklist

- [x] New and updated code has appropriate documentation
