### PR TITLE
improvement: add an ability to configure bridge nodes via options

### DIFF
--- a/tests/helpers/common/bridge.go
+++ b/tests/helpers/common/bridge.go
@@ -3,21 +3,24 @@ package common
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/celestiaorg/celestia-node/nodebuilder"
 	"github.com/celestiaorg/celestia-node/nodebuilder/node"
-	"github.com/celestiaorg/test-infra/testkit"
-	"github.com/celestiaorg/test-infra/testkit/appkit"
-	"github.com/celestiaorg/test-infra/testkit/nodekit"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/testground/sdk-go/run"
 	"github.com/testground/sdk-go/runtime"
 	"github.com/testground/sdk-go/sync"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
-	"os"
+	"go.uber.org/fx"
+
+	"github.com/celestiaorg/test-infra/testkit"
+	"github.com/celestiaorg/test-infra/testkit/appkit"
+	"github.com/celestiaorg/test-infra/testkit/nodekit"
 )
 
-func BuildBridge(ctx context.Context, runenv *runtime.RunEnv, initCtx *run.InitContext) (*nodebuilder.Node, error) {
+func BuildBridge(ctx context.Context, runenv *runtime.RunEnv, initCtx *run.InitContext, opts ...fx.Option) (*nodebuilder.Node, error) {
 	syncclient := initCtx.SyncClient
 
 	err := <-syncclient.MustBarrier(ctx, testkit.ValidatorReadyTopic, runenv.IntParam("validator")).C
@@ -61,11 +64,13 @@ func BuildBridge(ctx context.Context, runenv *runtime.RunEnv, initCtx *run.InitC
 		otlpmetrichttp.WithEndpoint(runenv.StringParam("otel-collector-address")),
 		otlpmetrichttp.WithInsecure(),
 	}
-	nd, err := nodekit.NewNode(ndhome, node.Bridge, runenv.StringParam("p2p-network"), cfg,
-		nodebuilder.WithMetrics(
-			optlOpts,
-			node.Bridge,
-		))
+
+	opts = append(opts, nodebuilder.WithMetrics(
+		optlOpts,
+		node.Bridge,
+	))
+
+	nd, err := nodekit.NewNode(ndhome, node.Bridge, runenv.StringParam("p2p-network"), cfg, opts...)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Overview
Extending input params of `BuildBridge` in order to configure bridge nodes with custom options.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
